### PR TITLE
Improve lada.kz parsing for new layout

### DIFF
--- a/parsing-lada.xml
+++ b/parsing-lada.xml
@@ -312,16 +312,17 @@ HTML;
 		$enabled_1 = ($enabled === 1) ? "selected" : "";
 		$enabled_0 = ($enabled === 0) ? "selected" : "";
 
-		$kyzylorda_news_selected = "";
-		$mgorod_selected = "";
-		$otyrar_selected = "";
-		$diapazon_selected = "";
-		$pavlodarnews_selected = "";
-		$azh_selected = "";
-		
-		$tengri_selected = "";
-		$buh_selected = "";
-		$mybuh_alluseful_selected = "";
+                $kyzylorda_news_selected = "";
+                $mgorod_selected = "";
+                $otyrar_selected = "";
+                $diapazon_selected = "";
+                $pavlodarnews_selected = "";
+                $azh_selected = "";
+                $lada_selected = "";
+
+                $tengri_selected = "";
+                $buh_selected = "";
+                $mybuh_alluseful_selected = "";
 
 		if ($settings['source'] == "kyzylorda_news")
 		{
@@ -343,14 +344,18 @@ HTML;
 		{
 			$pavlodarnews_selected = "selected";
 		}
-		if ($settings['source'] == "azh")
-		{
-			$azh_selected = "selected";
-		}		
-		if ($settings['source'] == "tengri")
-		{
-			$tengri_selected = "selected";
-		}
+                if ($settings['source'] == "azh")
+                {
+                        $azh_selected = "selected";
+                }
+                if ($settings['source'] == "lada")
+                {
+                        $lada_selected = "selected";
+                }
+                if ($settings['source'] == "tengri")
+                {
+                        $tengri_selected = "selected";
+                }
 		
 		if ($settings['source'] == "mybuh_news")
 		{
@@ -401,9 +406,10 @@ HTML;
 					<option value="kyzylorda_news" {$kyzylorda_news_selected}>Kyzylorda-news</option>
 					<option value="mgorod" {$mgorod_selected}>Mgorod</option>
 					<option value="otyrar" {$otyrar_selected}>Otyrar</option>
-					<option value="diapazon" {$diapazon_selected}>Diapazon</option>
-					<option value="pavlodarnews" {$pavlodarnews_selected}>Pavlodarnews</option>
-					<option value="azh" {$azh_selected}>Azh</option>
+                                        <option value="diapazon" {$diapazon_selected}>Diapazon</option>
+                                        <option value="pavlodarnews" {$pavlodarnews_selected}>Pavlodarnews</option>
+                                        <option value="azh" {$azh_selected}>Azh</option>
+                                        <option value="lada" {$lada_selected}>Lada.kz</option>
 				</select>
 				<script>
 				  document.addEventListener('DOMContentLoaded', function () {
@@ -732,10 +738,11 @@ HTML;
 					<option value="kyzylorda_news">Kyzylorda-news</option>
 					<option value="mgorod">Mgorod</option>
 					<option value="otyrar">Otyrar</option>
-					<option value="diapazon">Diapazon</option>
-					<option value="pavlodarnews">Pavlodarnews</option>
-					<option value="azh">Azh</option>					
-				</select>
+                                        <option value="diapazon">Diapazon</option>
+                                        <option value="pavlodarnews">Pavlodarnews</option>
+                                        <option value="azh">Azh</option>
+                                        <option value="lada">Lada.kz</option>
+                                </select>
 				<script>
 				  document.addEventListener('DOMContentLoaded', function () {
 				  const select = document.getElementById('source');
@@ -4311,6 +4318,9 @@ if ($action == "list") {
                     case "azh":
                         $count = include(DLEPlugins::Check(ENGINE_DIR . '/modules/parse_azh_list.php'));
                         break;
+                    case "lada":
+                        $count = include(DLEPlugins::Check(ENGINE_DIR . '/modules/parse_lada_list.php'));
+                        break;
                     case "tengri":
                         $count = include(DLEPlugins::Check(ENGINE_DIR . '/modules/parse_tengri_list.php'));
                         break;
@@ -4425,16 +4435,21 @@ if ($action == "list") {
 						$i++;
 						include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_pavlodarnews.php'));
 					}
-					if ($item['source'] == "azh")
-					{
-						$i++;
-						include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_azh.php'));
-					}					
-					if ($item['source'] == "tengri")
-					{
-						$i++;
+                                        if ($item['source'] == "azh")
+                                        {
+                                                $i++;
+                                                include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_azh.php'));
+                                        }
+                                        if ($item['source'] == "lada")
+                                        {
+                                                $i++;
+                                                include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_lada.php'));
+                                        }
+                                        if ($item['source'] == "tengri")
+                                        {
+                                                $i++;
 
-						include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_tengri.php'));
+                                                include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_tengri.php'));
 					}
 					if ($item['source'] == "mybuh_news")
 					{
@@ -4494,14 +4509,18 @@ if ($action == "list") {
 					
 					addLog('Выбран источник - ' .  $url);
 
-					if ($settings['source'] == "tengri")
-					{
-						include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_tengri.php'));
-					}
-					if ($settings['source'] == "mybuh_news")
-					{
-						include (DLEPlugins::Check(ENGINE_DIR . '/modules/mybuh_news.php'));
-					}
+                                        if ($settings['source'] == "tengri")
+                                        {
+                                                include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_tengri.php'));
+                                        }
+                                        if ($settings['source'] == "lada")
+                                        {
+                                                include (DLEPlugins::Check(ENGINE_DIR . '/modules/parse_lada.php'));
+                                        }
+                                        if ($settings['source'] == "mybuh_news")
+                                        {
+                                                include (DLEPlugins::Check(ENGINE_DIR . '/modules/mybuh_news.php'));
+                                        }
 					if ($settings['source'] == "mybuh_alluseful")
 					{
 						include (DLEPlugins::Check(ENGINE_DIR . '/modules/mybuh_alluseful.php'));
@@ -5632,11 +5651,11 @@ return $count;
 			<enabled>1</enabled>
 		</operation>
 	</file>
-	<file name="engine/modules/mybuh_alluseful.php">
-		<operation action="create">
-			<replacecode><![CDATA[<?php
+        <file name="engine/modules/mybuh_alluseful.php">
+                <operation action="create">
+                        <replacecode><![CDATA[<?php
 
-	$post_count = $settings['post_count'];
+        $post_count = $settings['post_count'];
 
 	$title = $item['title'];
 	$link = $item['post_link'];
@@ -5672,16 +5691,628 @@ return $count;
 
 	$images = array();
 
-	$res = addPost($short_story, "mybuh", "", $title, $text, "", "", $link, $images, $category_news);
+        $res = addPost($short_story, "mybuh", "", $title, $text, "", "", $link, $images, $category_news);
 ?>]]></replacecode>
-			<enabled>1</enabled>
-		</operation>
-	</file>
-	<file name="engine/modules/post_send.php">
-		<operation action="create">
-			<replacecode><![CDATA[<?php
+                        <enabled>1</enabled>
+                </operation>
+        </file>
+        <file name="engine/modules/parse_lada_list.php">
+                <operation action="create">
+                        <replacecode><![CDATA[<?php
+require_once (DLEPlugins::Check(ENGINE_DIR . '/modules/helpers.php'));
 
-			/*telegram*/
+if (!function_exists('lada_normalize_url')) {
+        function lada_normalize_url(string $path, string $base): string
+        {
+                $path = trim($path);
+
+                if ($path === '') {
+                        return '';
+                }
+
+                if (strpos($path, '//') === 0) {
+                        return 'https:' . $path;
+                }
+
+                if (preg_match('#^https?://#i', $path)) {
+                        return $path;
+                }
+
+                if ($path[0] === '/') {
+                        return rtrim($base, '/') . $path;
+                }
+
+                return rtrim($base, '/') . '/' . $path;
+        }
+}
+
+if (!function_exists('lada_import_html_fragment')) {
+        function lada_import_html_fragment(DOMDocument $dom, DOMElement $target, string $html): void
+        {
+                $html = trim($html);
+
+                if ($html === '') {
+                        return;
+                }
+
+                $previousState = libxml_use_internal_errors(true);
+                $tempDom = new DOMDocument('1.0', 'UTF-8');
+                $tempDom->loadHTML('<?xml encoding="utf-8"?>' . $html);
+                libxml_clear_errors();
+                libxml_use_internal_errors($previousState);
+
+                $body = $tempDom->getElementsByTagName('body')->item(0);
+
+                if (!$body) {
+                        return;
+                }
+
+                while ($target->firstChild) {
+                        $target->removeChild($target->firstChild);
+                }
+
+                foreach ($body->childNodes as $child) {
+                        $imported = $dom->importNode($child, true);
+                        $target->appendChild($imported);
+                }
+        }
+}
+
+if (!function_exists('lada_collect_from_array')) {
+        function lada_collect_from_array($data, array &$result): void
+        {
+                if (!is_array($data)) {
+                        return;
+                }
+
+                $hasUrl = isset($data['url']) && strpos($data['url'], '/aktau_news/') !== false;
+                $hasTitle = isset($data['title']) || isset($data['name']);
+
+                if ($hasUrl && $hasTitle) {
+                        $result[] = $data;
+                }
+
+                foreach ($data as $value) {
+                        lada_collect_from_array($value, $result);
+                }
+        }
+}
+
+$baseUrl = 'https://www.lada.kz';
+$content = getPageContent($url, 15, false);
+
+if (!$content) {
+        return 0;
+}
+
+$previousState = libxml_use_internal_errors(true);
+$dom = new DOMDocument('1.0', 'UTF-8');
+$dom->loadHTML('<?xml encoding="utf-8"?>' . $content);
+libxml_clear_errors();
+libxml_use_internal_errors($previousState);
+
+$xpath = new DOMXPath($dom);
+$seen = [];
+$count = 0;
+
+$cards = $xpath->query("//div[contains(concat(' ', normalize-space(@class), ' '), ' news ') and contains(concat(' ', normalize-space(@class), ' '), ' col-lg-4 ')]");
+
+foreach ($cards as $card) {
+        $linkNode = $xpath->query(
+                ".//a[contains(concat(' ', normalize-space(@class), ' '), ' news__link ')][contains(@href, '/aktau_news/') and not(contains(@href, '#'))]",
+                $card
+        )->item(0);
+
+        if (!$linkNode) {
+                $linkNode = $xpath->query(".//a[contains(@href, '/aktau_news/') and not(contains(@href, '#'))]", $card)->item(0);
+        }
+
+        if (!$linkNode) {
+                continue;
+        }
+
+        $href = trim($linkNode->getAttribute('href'));
+
+        if ($href === '') {
+                continue;
+        }
+
+        $fullLink = lada_normalize_url($href, $baseUrl);
+
+        if ($fullLink === '' || isset($seen[$fullLink])) {
+                continue;
+        }
+
+        $seen[$fullLink] = true;
+
+        $title = trim(preg_replace('/\s+/u', ' ', $linkNode->textContent));
+
+        if ($title === '') {
+                $heading = $xpath->query(".//h1|.//h2|.//h3|.//h4", $card)->item(0);
+
+                if ($heading) {
+                        $title = trim(preg_replace('/\s+/u', ' ', $heading->textContent));
+                }
+        }
+
+        if ($title === '') {
+                continue;
+        }
+
+        $poster = '';
+        $imageNode = $xpath->query(".//img", $card)->item(0);
+
+        if ($imageNode) {
+                $src = $imageNode->getAttribute('src');
+
+                if ($src === '') {
+                        $src = $imageNode->getAttribute('data-src');
+                }
+
+                if ($src === '') {
+                        $src = $imageNode->getAttribute('data-original');
+                }
+
+                $poster = lada_normalize_url($src, $baseUrl);
+        }
+
+        $short_story = '';
+        $summaryNode = $xpath->query(".//*[contains(@class,'descr') or contains(@class,'intro') or contains(@class,'announce') or contains(@class,'text')]", $card)->item(0);
+
+        if ($summaryNode) {
+                $short_story = trim(preg_replace('/\s+/u', ' ', $summaryNode->textContent));
+        }
+
+        $safe_link = $db->safesql($fullLink);
+        $is_post = $db->super_query("SELECT count(*) as count FROM " . PREFIX . "_post WHERE url='$safe_link' LIMIT 1");
+
+        if ($is_post['count'] > 0) {
+                continue;
+        }
+
+        if (addToList("lada", $title, $poster, $fullLink, $short_story, $category_news, $file)) {
+                $count++;
+        }
+}
+
+$links = $xpath->query("//a[contains(@href, '/aktau_news/') and not(contains(@href, '#'))]");
+
+foreach ($links as $linkNode) {
+        $href = trim($linkNode->getAttribute('href'));
+
+        if ($href === '') {
+                continue;
+        }
+
+        $fullLink = lada_normalize_url($href, $baseUrl);
+
+        if ($fullLink === '' || isset($seen[$fullLink])) {
+                continue;
+        }
+
+        $seen[$fullLink] = true;
+
+        $title = trim(preg_replace('/\s+/u', ' ', $linkNode->textContent));
+
+        $container = $linkNode;
+        $depth = 0;
+
+        while ($container && $depth < 6) {
+                $container = $container->parentNode;
+                $depth++;
+
+                if (!$container || $container->nodeType !== XML_ELEMENT_NODE) {
+                        continue;
+                }
+
+                $classAttr = $container->attributes->getNamedItem('class');
+                if ($classAttr && preg_match('/news|item|card|story|article|list/i', $classAttr->nodeValue)) {
+                        break;
+                }
+        }
+
+        if (!$container || $container->nodeType !== XML_ELEMENT_NODE) {
+                $container = $linkNode->parentNode;
+        }
+
+        if ($title === '' && $container) {
+                $heading = $xpath->query(".//h1|.//h2|.//h3|.//h4", $container)->item(0);
+                if ($heading) {
+                        $title = trim(preg_replace('/\s+/u', ' ', $heading->textContent));
+                }
+        }
+
+        if ($title === '') {
+                continue;
+        }
+
+        $short_story = '';
+
+        if ($container) {
+                foreach ($xpath->query(".//p", $container) as $paragraph) {
+                        $text = trim(preg_replace('/\s+/u', ' ', $paragraph->textContent));
+                        if ($text !== '') {
+                                $short_story = $text;
+                                break;
+                        }
+                }
+
+                if ($short_story === '') {
+                        $descNode = $xpath->query(".//*[contains(@class,'descr') or contains(@class,'intro') or contains(@class,'announce') or contains(@class,'text')]", $container)->item(0);
+                        if ($descNode) {
+                                $short_story = trim(preg_replace('/\s+/u', ' ', $descNode->textContent));
+                        }
+                }
+        }
+
+        $poster = '';
+
+        if ($container) {
+                foreach ($xpath->query(".//img", $container) as $img) {
+                        $src = $img->getAttribute('src') ?: $img->getAttribute('data-src') ?: $img->getAttribute('data-original');
+                        $src = lada_normalize_url($src, $baseUrl);
+
+                        if ($src !== '') {
+                                $poster = $src;
+                                break;
+                        }
+                }
+        }
+
+        $safe_link = $db->safesql($fullLink);
+        $is_post = $db->super_query("SELECT count(*) as count FROM " . PREFIX . "_post WHERE url='$safe_link' LIMIT 1");
+
+        if ($is_post['count'] > 0) {
+                continue;
+        }
+
+        if (addToList("lada", $title, $poster, $fullLink, $short_story, $category_news, $file)) {
+                $count++;
+        }
+}
+
+if ($count === 0 && preg_match('#window.__NUXT__\s*=\s*(\{.*?\});#is', $content, $nuxtMatch)) {
+        $nuxtData = json_decode($nuxtMatch[1], true);
+        $items = [];
+        lada_collect_from_array($nuxtData, $items);
+
+        foreach ($items as $entry) {
+                $entryLink = isset($entry['url']) ? lada_normalize_url($entry['url'], $baseUrl) : '';
+
+                if ($entryLink === '' || isset($seen[$entryLink])) {
+                        continue;
+                }
+
+                $entryTitle = '';
+
+                if (!empty($entry['title'])) {
+                        $entryTitle = trim($entry['title']);
+                } elseif (!empty($entry['name'])) {
+                        $entryTitle = trim($entry['name']);
+                }
+
+                if ($entryTitle === '') {
+                        continue;
+                }
+
+                $entryShort = '';
+
+                foreach (['announce', 'description', 'anons', 'preview_text'] as $shortKey) {
+                        if (!empty($entry[$shortKey])) {
+                                $entryShort = trim($entry[$shortKey]);
+                                break;
+                        }
+                }
+
+                $entryPoster = '';
+
+                foreach (['image', 'img', 'picture', 'preview'] as $posterKey) {
+                        if (!empty($entry[$posterKey])) {
+                                $entryPoster = lada_normalize_url($entry[$posterKey], $baseUrl);
+                                if ($entryPoster !== '') {
+                                        break;
+                                }
+                        }
+                }
+
+                $safe_link = $db->safesql($entryLink);
+                $is_post = $db->super_query("SELECT count(*) as count FROM " . PREFIX . "_post WHERE url='$safe_link' LIMIT 1");
+
+                if ($is_post['count'] > 0) {
+                        continue;
+                }
+
+                if (addToList("lada", $entryTitle, $entryPoster, $entryLink, $entryShort, $category_news, $file)) {
+                        $seen[$entryLink] = true;
+                        $count++;
+                }
+        }
+}
+
+return $count;
+?>]]></replacecode>
+                        <enabled>1</enabled>
+                </operation>
+        </file>
+        <file name="engine/modules/parse_lada.php">
+                <operation action="create">
+                        <replacecode><![CDATA[<?php
+require_once (DLEPlugins::Check(ENGINE_DIR . '/modules/helpers.php'));
+
+if (!function_exists('lada_normalize_url')) {
+        function lada_normalize_url(string $path, string $base): string
+        {
+                $path = trim($path);
+
+                if ($path === '') {
+                        return '';
+                }
+
+                if (strpos($path, '//') === 0) {
+                        return 'https:' . $path;
+                }
+
+                if (preg_match('#^https?://#i', $path)) {
+                        return $path;
+                }
+
+                if ($path[0] === '/') {
+                        return rtrim($base, '/') . $path;
+                }
+
+                return rtrim($base, '/') . '/' . $path;
+        }
+}
+
+$baseUrl = 'https://www.lada.kz';
+
+$title = $item['title'];
+$post_link = $item['post_link'];
+$short_story = $item['short_story'];
+$category_news = $item['category'];
+$poster = $item['poster'];
+
+$content = getPageContent($post_link, 20, false);
+
+if (!$content) {
+        return;
+}
+
+$previousState = libxml_use_internal_errors(true);
+$dom = new DOMDocument('1.0', 'UTF-8');
+$dom->loadHTML('<?xml encoding="utf-8"?>' . $content);
+libxml_clear_errors();
+libxml_use_internal_errors($previousState);
+
+$xpath = new DOMXPath($dom);
+
+$selectors = [
+        "//div[contains(@class,'news__content')]",
+        "//div[contains(@class,'news-detail__content')]",
+        "//div[contains(@class,'article__content')]",
+        "//div[contains(@class,'article-body')]",
+        "//div[contains(@class,'article') and contains(@class,'content')]",
+        "//article[contains(@class,'news')]",
+        "//article[contains(@class,'article')]",
+        "//div[contains(@class,'fullstory')]",
+        "//div[contains(@class,'news-detail')]//div[contains(@class,'content')]",
+        "//div[contains(@class,'post__text')]",
+        "//div[contains(@class,'content') and contains(@class,'text')]"
+];
+
+$contentNode = null;
+
+foreach ($selectors as $selector) {
+        $candidate = $xpath->query($selector)->item(0);
+
+        if ($candidate) {
+                $contentNode = $candidate;
+                break;
+        }
+}
+
+if (!$contentNode) {
+        $contentNode = $xpath->query("//article")->item(0);
+}
+
+if (!$contentNode) {
+        $contentNode = $xpath->query("//div[contains(@class,'content')]")->item(0);
+}
+
+if (!$contentNode) {
+        return;
+}
+
+$originalHtml = '';
+
+if ($contentNode instanceof DOMElement) {
+        $originalHtml = $contentNode->getAttribute('data-original');
+}
+
+if ($originalHtml !== '') {
+        $decoded = html_entity_decode($originalHtml, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        lada_import_html_fragment($dom, $contentNode, $decoded);
+}
+
+$extractNode = $xpath->query("//div[contains(@class,'news__extract')]")->item(0);
+$preparedExtract = '';
+
+if ($extractNode) {
+        if ($extractNode instanceof DOMElement) {
+                $dataOriginal = $extractNode->getAttribute('data-original');
+
+                if ($dataOriginal !== '') {
+                        $decodedExtract = html_entity_decode($dataOriginal, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+                        $previousState = libxml_use_internal_errors(true);
+                        $tempDom = new DOMDocument('1.0', 'UTF-8');
+                        $tempDom->loadHTML('<?xml encoding="utf-8"?>' . $decodedExtract);
+                        libxml_clear_errors();
+                        libxml_use_internal_errors($previousState);
+
+                        $body = $tempDom->getElementsByTagName('body')->item(0);
+
+                        if ($body) {
+                                $preparedExtract = trim(preg_replace('/\s+/u', ' ', $body->textContent));
+                        }
+                }
+        }
+
+        if ($preparedExtract === '') {
+                $preparedExtract = trim(preg_replace('/\s+/u', ' ', $extractNode->textContent));
+        }
+}
+
+$removeSelectors = [
+        ".//script",
+        ".//style",
+        ".//noscript",
+        ".//div[contains(@class,'share')]",
+        ".//div[contains(@class,'social')]",
+        ".//div[contains(@class,'banner')]",
+        ".//div[contains(@class,'adv')]",
+        ".//div[contains(@class,'advert')]",
+        ".//div[contains(@class,'promo')]",
+        ".//div[contains(@class,'subscribe')]",
+        ".//div[contains(@class,'breadcrumbs')]",
+        ".//div[contains(@class,'tags')]",
+        ".//ul[contains(@class,'tags')]",
+        ".//div[contains(@class,'source')]",
+        ".//div[contains(@class,'author')]",
+        ".//section[contains(@class,'related')]",
+        ".//aside",
+        ".//footer",
+        ".//div[contains(@class,'news__extract')]",
+        ".//div[contains(@class,'news__reactions_widget')]",
+        ".//div[contains(@class,'tg-subscribe')]",
+        ".//div[contains(@class,'partner-news')]",
+        ".//*[contains(@class,'google-auto-placed')]",
+        ".//div[contains(@class,'comments')]",
+        ".//button",
+        ".//input"
+];
+
+foreach ($removeSelectors as $selector) {
+        $nodes = $xpath->query($selector, $contentNode);
+
+        for ($index = $nodes->length - 1; $index >= 0; $index--) {
+                $node = $nodes->item($index);
+
+                if ($node && $node->parentNode) {
+                        $node->parentNode->removeChild($node);
+                }
+        }
+}
+
+$commentNodes = $xpath->query('.//comment()', $contentNode);
+
+for ($index = $commentNodes->length - 1; $index >= 0; $index--) {
+        $comment = $commentNodes->item($index);
+
+        if ($comment && $comment->parentNode) {
+                $comment->parentNode->removeChild($comment);
+        }
+}
+
+$images = [];
+$imageNodes = $xpath->query('.//img', $contentNode);
+
+for ($index = $imageNodes->length - 1; $index >= 0; $index--) {
+        $img = $imageNodes->item($index);
+        if (!$img) {
+                continue;
+        }
+
+        $src = $img->getAttribute('src');
+
+        if ($src === '') {
+                $src = $img->getAttribute('data-src');
+        }
+
+        if ($src === '') {
+                $src = $img->getAttribute('data-original');
+        }
+
+        if ($src === '') {
+                $src = $img->getAttribute('data-lazy');
+        }
+
+        $normalized = lada_normalize_url($src, $baseUrl);
+
+        if ($normalized === '') {
+                if ($img->parentNode) {
+                        $img->parentNode->removeChild($img);
+                }
+
+                continue;
+        }
+
+        $images[] = $normalized;
+        $img->setAttribute('src', $normalized);
+        $img->removeAttribute('data-src');
+        $img->removeAttribute('data-original');
+        $img->removeAttribute('data-lazy');
+        $img->removeAttribute('loading');
+}
+
+$images = array_values(array_unique($images));
+
+if (trim($short_story) === '' && $preparedExtract !== '') {
+        $short_story = $preparedExtract;
+}
+
+if (trim($short_story) === '') {
+        $firstParagraph = $xpath->query('.//p', $contentNode)->item(0);
+
+        if ($firstParagraph) {
+                $short_story = trim(preg_replace('/\s+/u', ' ', $firstParagraph->textContent));
+        }
+}
+
+$anchorNodes = $xpath->query('.//a', $contentNode);
+
+for ($index = $anchorNodes->length - 1; $index >= 0; $index--) {
+        $anchor = $anchorNodes->item($index);
+
+        if (!$anchor) {
+                continue;
+        }
+
+        $fragment = $dom->createDocumentFragment();
+
+        while ($anchor->firstChild) {
+                $fragment->appendChild($anchor->firstChild);
+        }
+
+        if ($anchor->parentNode) {
+                $anchor->parentNode->replaceChild($fragment, $anchor);
+        }
+}
+
+$text = trim($dom->saveHTML($contentNode));
+
+if ($text === '') {
+        return;
+}
+
+if ($poster) {
+        $poster = lada_normalize_url($poster, $baseUrl);
+}
+
+if (!$poster && !empty($images)) {
+        $poster = $images[0];
+}
+
+addPost($short_story, "https://www.lada.kz", "", $title, $text, $poster, $poster, $post_link, $images, $category_news);
+?>]]></replacecode>
+                        <enabled>1</enabled>
+                </operation>
+        </file>
+        <file name="engine/modules/post_send.php">
+                <operation action="create">
+                        <replacecode><![CDATA[<?php
+
+                        /*telegram*/
 			if($c_url) {
 				$full_link = $config['http_home_url'] . $c_url . "/" . $row['id'] . "-" . $row['alt_name'] . ".html";
 			} else {


### PR DESCRIPTION
## Summary
- update the lada.kz list parser to target the new Aktau news card layout and prevent duplicate queue entries
- add a reusable helper for importing saved HTML fragments and extend the article parser cleanup for lada.kz pages
- derive short descriptions from the news extract block while stripping new reaction, subscribe, and ad widgets

## Testing
- php -l /tmp/parse_lada_list.php
- php -l /tmp/parse_lada.php

------
https://chatgpt.com/codex/tasks/task_e_68e54d8efa808332b92eb02680e03db0