### PR TITLE
Restrict lada.kz parser to news link cards

### DIFF
--- a/parsing-lada.xml
+++ b/parsing-lada.xml
@@ -5804,10 +5804,6 @@ foreach ($cards as $card) {
         )->item(0);
 
         if (!$linkNode) {
-                $linkNode = $xpath->query(".//a[contains(@href, '/aktau_news/') and not(contains(@href, '#'))]", $card)->item(0);
-        }
-
-        if (!$linkNode) {
                 continue;
         }
 
@@ -5875,7 +5871,7 @@ foreach ($cards as $card) {
         }
 }
 
-$links = $xpath->query("//a[contains(@href, '/aktau_news/') and not(contains(@href, '#'))]");
+$links = $xpath->query("//a[contains(concat(' ', normalize-space(@class), ' '), ' news__link ')][contains(@href, '/aktau_news/') and not(contains(@href, '#'))]");
 
 foreach ($links as $linkNode) {
         $href = trim($linkNode->getAttribute('href'));


### PR DESCRIPTION
## Summary
- ensure lada.kz parser only captures news links with the expected news__link class
- drop the fallback that collected every /aktau_news/ anchor to avoid pagination noise

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e55be4d2cc8332aae11b0d483af413