### PR TITLE
Clean up data-original attributes in parsed articles

### DIFF
--- a/parsing-lada.xml
+++ b/parsing-lada.xml
@@ -6263,6 +6263,22 @@ if ($originalHtml !== '') {
         lada_import_html_fragment($dom, $contentNode, $decoded);
 }
 
+if ($contentNode instanceof DOMElement && $contentNode->hasAttribute('data-original')) {
+        $contentNode->removeAttribute('data-original');
+}
+
+$dataOriginalNodes = $xpath->query(".//*[@data-original]", $contentNode);
+
+if ($dataOriginalNodes instanceof DOMNodeList) {
+        for ($index = 0; $index < $dataOriginalNodes->length; $index++) {
+                $nodeWithAttribute = $dataOriginalNodes->item($index);
+
+                if ($nodeWithAttribute instanceof DOMElement) {
+                        $nodeWithAttribute->removeAttribute('data-original');
+                }
+        }
+}
+
 $extractNode = $xpath->query("//div[contains(@class,'news__extract')]")->item(0);
 $preparedExtract = '';
 
@@ -6285,6 +6301,10 @@ if ($extractNode) {
                                 $preparedExtract = trim(preg_replace('/\s+/u', ' ', $body->textContent));
                         }
                 }
+        }
+
+        if ($extractNode instanceof DOMElement && $extractNode->hasAttribute('data-original')) {
+                $extractNode->removeAttribute('data-original');
         }
 
         if ($preparedExtract === '') {


### PR DESCRIPTION
## Summary
- strip the data-original attribute from the main content node after loading encoded HTML
- remove leftover data-original attributes from child nodes and the extract container so saved markup is clean

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f7bd4dc08332b0b2c9ff70fa63cd