### PR TITLE
Fix parser user lookup before acquiring post table lock

### DIFF
--- a/parsing-lada.xml
+++ b/parsing-lada.xml
@@ -5048,6 +5048,22 @@ if ($action == "list") {
                 $urlHash = $normalizedUrl !== '' ? md5($normalizedUrl) : '';
                 $safeUrl = $db->safesql($url);
                 $safeUrlHash = $db->safesql($urlHash);
+
+                $user_name = "Айгерим";
+
+                $user_group = $config['parser_user_group'];
+
+                $user_id = 0;
+                if ((int)$user_group>0)
+                {
+                        $user_row = $db->super_query("SELECT user_id, name FROM ".PREFIX."_users where user_group=".$user_group);
+
+                        if (is_array($user_row) && isset($user_row['user_id'])) {
+                                $user_name = $user_row['name'];
+                                $user_id = $user_row['user_id'];
+                        }
+                }
+
                 $hasUniqueUrlHash = ensurePostUrlHashConstraint();
                 $lockAcquired = false;
 
@@ -5197,19 +5213,6 @@ if ($action == "list") {
 		
 		$c_date = date( "Y-m-d H:i:s", $c_time);
 		
-		$user_name = "Айгерим";
-
-		$user_group = $config['parser_user_group'];
-
-		$user_id = 0;
-		if ((int)$user_group>0)
-		{
-			$user_id = $db->super_query("SELECT user_id, name FROM ".PREFIX."_users where user_group=".$user_group);
-			$user_name = $user_id['name'];
-			$user_id = $user_id['user_id'];
-		}
-
-
                         $sql="INSERT INTO ".PREFIX."_post set
                                                         approve=1,
                                                         category='$category_news',


### PR DESCRIPTION
## Summary
- move the configured parser user lookup ahead of the optional LOCK TABLES call to avoid querying unlocked tables
- add a defensive guard if the configured parser user group has no members

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e63eeaa41c8332b71da320b3a79d5f